### PR TITLE
Add a task to produce the sources jar

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -49,3 +49,11 @@ tasks.withType<Test> {
     isScanForTestClasses = false
     include("**/*.*")
 }
+
+tasks {
+      val sourcesJar by creating(Jar::class) {
+          archiveClassifier.set("sources")
+          from(sourceSets.main.get().allSource)
+          dependsOn(classes)
+   }
+}


### PR DESCRIPTION
This is useful if you're attempting to use the library in an other project.