### PR TITLE
Fix bug with nullable rules (found by github.com/ndw)

### DIFF
--- a/lib/src/main/scala/EarleyScala/Earley.scala
+++ b/lib/src/main/scala/EarleyScala/Earley.scala
@@ -76,6 +76,8 @@ case class Earley(grammar: Grammar) {
           S(i).append(newState)
         }
         oldState = newState
+      } else {
+        return // break when the algorithm hits the first non-nullable symbol [walking from the current symbol]
       }
     })
   }

--- a/lib/src/main/scala/EarleyScala/Grammar.scala
+++ b/lib/src/main/scala/EarleyScala/Grammar.scala
@@ -76,7 +76,7 @@ case class Grammar(startRuleName: String, rules: Seq[Rule]) {
           nullableSymbols.add(r.name)
         }
         else {
-          if (r.symbols.exists(t => t.isInstanceOf[NonTerminalSymbol] && nullableSymbols.contains(t.asInstanceOf[NonTerminalSymbol].ruleName))) {
+          if (r.symbols.forall(t => t.isInstanceOf[NonTerminalSymbol] && nullableSymbols.contains(t.asInstanceOf[NonTerminalSymbol].ruleName))) {
             nullableSymbols.add(r.name)
           }
         }

--- a/lib/src/test/scala/EarleyScala/testReproduceNullableAndAmbiguousGrammarBug.scala
+++ b/lib/src/test/scala/EarleyScala/testReproduceNullableAndAmbiguousGrammarBug.scala
@@ -1,0 +1,40 @@
+package earleyscala
+
+import junit.framework.TestCase
+import org.junit.FixMethodOrder
+import org.junit.runners.MethodSorters
+import org.junit.Test
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class testReproduceNullableAndAmbiguousGrammarBug extends TestCase {
+  val TreeUtils = new DisambiguatingTreeUtils
+
+  @Test
+  // This bug was found by ndw (github.com/ndw). 
+  def test_1_ndw_case: Unit = {
+    val grammar = Grammar("_0",
+      List(
+        Rule("_0", List(NonTerminalSymbol("block"))),
+        Rule("block", List(TerminalSymbol("\\{"), NonTerminalSymbol("_1"), TerminalSymbol("\\}"))),
+        Rule("statement", List(TerminalSymbol("a"))),
+        Rule("statement", List()),
+        Rule("_1", List(NonTerminalSymbol("_2"))),
+        Rule("_2", List(NonTerminalSymbol("statement"), NonTerminalSymbol("_3"))),
+        Rule("_2", List()),
+        Rule("_3", List(NonTerminalSymbol("_4"))),
+        Rule("_4", List(TerminalSymbol(";"), NonTerminalSymbol("statement"), NonTerminalSymbol("_3"))),
+        Rule("_4", List())
+      )
+    )
+
+    val input = "{a;}"
+    val earley = Earley(grammar)
+
+    val chart = earley.buildChart(input)
+    println(chart.repr())
+    val endState = chart.getLastStates.head
+    TreeUtils.createLeaves(endState, input)
+    println()
+    TreeUtils.createTree(endState, input)
+  }
+}


### PR DESCRIPTION
The original code that I wrote had some issues with the nullable grammar
rules.

Constructing the set of nullable rules in the grammar had a bug where
the rule would be marked as nullable if any of the symbols were
nullable. The proper behavior is to have it marked as nullable if all
the symbols are nullable.

The complete/predict step after walking a nullable symbol also had a bug
- it would check all symbols to see if they were nullable and add them
to the next state set. The correct behavior is only add nullable symbols
that follow the symbol until there's a non-nullable symbol.